### PR TITLE
Generate a release via `make release`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,9 @@ vendor:
 	go mod tidy
 	go mod vendor
 
+release: IMAGE_TAG = $(shell hack/version.sh)
+release: docker-build docker-push
+
 .PHONY: \
 	all \
 	check \

--- a/automation/release.sh
+++ b/automation/release.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -xe
+
+# This script tags current version and create a new release at github and pushes
+# to quay.io
+# To run it just do proper docker login and pass the git hub user password/token as
+# GITHUB_USER and GITHUB_TOKEN env variables.
+
+# To pass user/password from automations, idea is taken from [1]
+# [1] https://stackoverflow.com/questions/8536732/can-i-hold-git-credentials-in-environment-variables
+git config credential.helper '!f() { sleep 1; echo "username=${GITHUB_USER}"; echo "password=${GITHUB_TOKEN}"; }; f'
+
+source automation/check-patch.setup.sh
+cd ${TMP_PROJECT_PATH}
+make release

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+version_file=version/version.go
+# If we don't pass a version just show current one
+if [ -z "$1" ]; then
+    grep = $version_file | sed -r 's/.*= \"(.*)"$$/v\1/g'
+# else change it
+else
+    sed -i "s/= \".*\"$/= \"$1\"/g" $version_file
+fi

--- a/version/description
+++ b/version/description
@@ -1,0 +1,13 @@
+v0.0.0
+
+Anything is better than nothing. When it comes to docker images.
+
+Features:
+* macvtap device plugin, with explicit configuration (#2)
+* macvtap CNI plugin is installed across the cluster (#4)
+
+* add README (#9)
+
+```
+docker pull quay.io/kubevirt/macvtap-cni:v0.0.0
+```

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,5 @@
+package version
+
+var (
+	Version = "0.0.0"
+)


### PR DESCRIPTION
Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Enables the developers to generate releases via `make release`.
Adds a v0.0.0 dummy release - version/...

