### PR TITLE
Adding quotes in macvtap.yaml.in

### DIFF
--- a/hack/generate-manifests.sh
+++ b/hack/generate-manifests.sh
@@ -14,6 +14,8 @@ DESTINATION=${DESTINATION:-manifests}
 for template in templates/*.in; do
     name=$(basename ${template%.in})
     sed \
+        -e "s#'{{#{{#g" \
+        -e "s#}}'#}}#g" \
         -e "s#{{ .MacvtapImage }}#${MACVTAP_IMG}#g" \
         -e "s#{{ .CniMountPath }}#${CNI_MOUNT_PATH}#g" \
         -e "s#{{ .Namespace }}#${NAMESPACE}#g" \

--- a/templates/macvtap.yaml.in
+++ b/templates/macvtap.yaml.in
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: macvtap-cni
-  namespace: {{ .Namespace }}
+  namespace: '{{ .Namespace }}'
 spec:
   selector:
     matchLabels:
@@ -20,8 +20,8 @@ spec:
         envFrom:
           - configMapRef:
               name: macvtap-deviceplugin-config
-        image: {{ .MacvtapImage }}
-        imagePullPolicy: {{ .ImagePullPolicy }}
+        image: '{{ .MacvtapImage }}'
+        imagePullPolicy: '{{ .ImagePullPolicy }}'
         resources:
           requests:
             cpu: "60m"
@@ -34,8 +34,8 @@ spec:
       initContainers:
       - name: install-cni
         command: ['cp', '/macvtap-cni', '/host/opt/cni/bin/macvtap']
-        image: {{ .MacvtapImage }}
-        imagePullPolicy: {{ .ImagePullPolicy }}
+        image: '{{ .MacvtapImage }}'
+        imagePullPolicy: '{{ .ImagePullPolicy }}'
         securityContext:
           privileged: true
         volumeMounts:
@@ -48,4 +48,4 @@ spec:
             path: /var/lib/kubelet/device-plugins
         - name: cni
           hostPath:
-            path: {{ .CniMountPath }}
+            path: '{{ .CniMountPath }}'


### PR DESCRIPTION
Missing quotation causes issues when the yaml is being processed with yq

**What this PR does / why we need it**:
Adds quotation marks around `{{  }}` to macvtap.yaml.in so that it can be processed with `yq`.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```