### PR TITLE
Fix container command quotes in macvtap.yaml.in

### DIFF
--- a/templates/macvtap.yaml.in
+++ b/templates/macvtap.yaml.in
@@ -16,7 +16,7 @@ spec:
       hostPID: true
       containers:
       - name: macvtap-cni
-        command: [ "/macvtap-deviceplugin", "-v", "3", "-logtostderr"]
+        command: ["/macvtap-deviceplugin", "-v", "3", "-logtostderr"]
         envFrom:
           - configMapRef:
               name: macvtap-deviceplugin-config
@@ -33,7 +33,7 @@ spec:
             mountPath: /var/lib/kubelet/device-plugins
       initContainers:
       - name: install-cni
-        command: ['cp', '/macvtap-cni', '/host/opt/cni/bin/macvtap']
+        command: ["cp", "/macvtap-cni", "/host/opt/cni/bin/macvtap"]
         image: '{{ .MacvtapImage }}'
         imagePullPolicy: '{{ .ImagePullPolicy }}'
         securityContext:


### PR DESCRIPTION
Use double quotes instead of single quotes in:
command: ["cp", "/macvtap-cni", "/host/opt/cni/bin/macvtap"]

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release notes**:

```release notes
NONE
```