### PR TITLE
Release v0.4.0

### DIFF
--- a/version/description
+++ b/version/description
@@ -1,8 +1,11 @@
-v0.3.1
+v0.4.0
+Bump dependencies to align with kubernetes v1.19.1
 
+Features:
+* Bump device-plugin-manager and kubelet deps (#30)
+* Bump dependencies (#29)
 Bugs:
-* Fix container command quotes in macvtap.yaml.in (#27)
 
 ```
-docker pull quay.io/kubevirt/macvtap-cni:v0.3.1
+docker pull quay.io/kubevirt/macvtap-cni:v0.4.0
 ```

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.3.1"
+	Version = "0.4.0"
 )


### PR DESCRIPTION
Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

**What this PR does / why we need it**:
This release updates dependencies to align with kubernetes v1.19.1.

**Special notes for your reviewer**:

**Release notes**

```release-note
NONE
```