### PR TITLE
Release v0.4.1

### DIFF
--- a/version/description
+++ b/version/description
@@ -1,11 +1,6 @@
-v0.4.0
-Bump dependencies to align with kubernetes v1.19.1
-
+v0.4.1
 Features:
-* Bump device-plugin-manager and kubelet deps (#30)
-* Bump dependencies (#29)
-Bugs:
-
+* enable macvtap to be tested as part of operator tier1
 ```
-docker pull quay.io/kubevirt/macvtap-cni:v0.4.0
+docker pull quay.io/kubevirt/macvtap-cni:v0.4.1
 ```

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.4.0"
+	Version = "0.4.1"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR issues a new patch release v0.4.1.
it's sole content is to enable to run tier1 tests on external operators, such as [CNAO](https://github.com/kubevirt/cluster-network-addons-operator)
related PR in CNAO: [macvtap tier1 automation](https://github.com/kubevirt/cluster-network-addons-operator/pull/638)

**Special notes for your reviewer**:

```release-note
Release v0.4.1
```