### PR TITLE
ci, Add vendored-go to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ whitespace-check
 whitespace-format
 vet
 
+# Temporary build files
+build/_output
+
 # Local kubevirtci cluster
 _kubevirtci/
 

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -5,4 +5,4 @@ set -ex
 source ./cluster/kubevirtci.sh
 
 KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)}
-go test ./tests/e2e --kubeconfig ${KUBECONFIG} -ginkgo.v
+${GO} test ./tests/e2e --kubeconfig ${KUBECONFIG} -ginkgo.v

--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xe
+
+destination=$1
+version=$(grep "^go " go.mod | awk '{print $2}')
+tarball=go$version.linux-amd64.tar.gz
+url=https://dl.google.com/go/
+
+mkdir -p $destination
+curl -L $url/$tarball -o $destination/$tarball
+tar -xf $destination/$tarball -C $destination


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, if go is not installed on the host
then e2e tests will fail.
We want to be independent of this.
Added install of vendored go, according to
the version in go.mod

**Special notes for your reviewer**:
