### PR TITLE
ci, Fix wrong daemonset call in macvtap tests

### DIFF
--- a/tests/e2e/macvtap_test.go
+++ b/tests/e2e/macvtap_test.go
@@ -240,7 +240,7 @@ func filterPods(pods []v1.Pod, filterFunction func(v1.Pod) bool) []v1.Pod {
 
 func findMacvtapNamespace() (string, error) {
 	macvtapDaemonSetName := "macvtap-cni"
-	daemonSetList, err := clientset.ExtensionsV1beta1().DaemonSets(v1.NamespaceAll).List(context.TODO(), metav1.ListOptions{
+	daemonSetList, err := clientset.AppsV1().DaemonSets(v1.NamespaceAll).List(context.TODO(), metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("metadata.name=%s", macvtapDaemonSetName),
 	})
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Curretnly, we are using an old Daemonset version (extensions/v1beta1)
While this works on the repo, it will fail if run from
a repo using a newer Daemonset version (apps/v1).
The solution is to use the latest version that recognizes also
the old version.

**Special notes for your reviewer**:
