### PR TITLE
Release v0.4.2

### DIFF
--- a/version/description
+++ b/version/description
@@ -1,6 +1,8 @@
-v0.4.1
+v0.4.2
 Features:
-* enable macvtap to be tested as part of operator tier1
+* ci, Add vendored-go to Makefile
+Bugs:
+* ci, Fix wrong Daemonset call in macvtap tests
 ```
-docker pull quay.io/kubevirt/macvtap-cni:v0.4.1
+docker pull quay.io/kubevirt/macvtap-cni:v0.4.2
 ```

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.4.1"
+	Version = "0.4.2"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR issues a new patch release v0.4.2

**Special notes for your reviewer**:

**Release note**:

```release-note
Release v0.4.2
```