### PR TITLE
Rename master api

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The value is a json array and each element of the array is a separate resource
 to be made available:
 
 * `name` (string, required) the name of the resource
-* `master` (string, required) the name of the macvtap lower link
+* `lowerDevice` (string, required) the name of the macvtap lower link
 * `mode` (string, optional, default=bridge) the macvtap operating mode
 * `capacity` (uint, optional, default=100) the capacity of the resource
 
@@ -36,7 +36,7 @@ data:
   DP_MACVTAP_CONF: |
     [ {
         "name" : "dataplane",
-        "master" : "eth0",
+        "lowerDevice" : "eth0",
         "mode": "bridge",
         "capacity" : 50
     } ]

--- a/examples/macvtap-deviceplugin-config-explicit.yaml
+++ b/examples/macvtap-deviceplugin-config-explicit.yaml
@@ -6,7 +6,7 @@ data:
   DP_MACVTAP_CONF: >-
     [ {
         "name" : "eth0",
-        "master" : "eth0",
+        "lowerDevice" : "eth0",
         "mode": "bridge",
         "capacity" : 50
      } ]

--- a/pkg/deviceplugin/lister.go
+++ b/pkg/deviceplugin/lister.go
@@ -16,10 +16,10 @@ const (
 )
 
 type macvtapConfig struct {
-	Name     string `json:"name"`
-	Master   string `json:"master"`
-	Mode     string `json:"mode"`
-	Capacity int    `json:"capacity"`
+	Name        string `json:"name"`
+	LowerDevice string `json:"lowerDevice"`
+	Mode        string `json:"mode"`
+	Capacity    int    `json:"capacity"`
 }
 
 type macvtapLister struct {
@@ -157,13 +157,13 @@ func (ml *macvtapLister) NewPlugin(name string) dpm.PluginInterface {
 	c, ok := ml.Config[name]
 	if !ok {
 		c = macvtapConfig{
-			Name:     name,
-			Master:   name,
-			Mode:     DefaultMode,
-			Capacity: DefaultCapacity,
+			Name:        name,
+			LowerDevice: name,
+			Mode:        DefaultMode,
+			Capacity:    DefaultCapacity,
 		}
 	}
 
 	glog.V(3).Infof("Creating device plugin with config %+v", c)
-	return NewMacvtapDevicePlugin(c.Name, c.Master, c.Mode, c.Capacity, ml.NetNsPath)
+	return NewMacvtapDevicePlugin(c.Name, c.LowerDevice, c.Mode, c.Capacity, ml.NetNsPath)
 }

--- a/pkg/deviceplugin/plugin.go
+++ b/pkg/deviceplugin/plugin.go
@@ -22,19 +22,19 @@ const (
 )
 
 type macvtapDevicePlugin struct {
-	Name     string
-	Master   string
-	Mode     string
-	Capacity int
+	Name        string
+	LowerDevice string
+	Mode        string
+	Capacity    int
 	// NetNsPath is the path to the network namespace the plugin operates in.
 	NetNsPath   string
 	stopWatcher chan struct{}
 }
 
-func NewMacvtapDevicePlugin(name string, master string, mode string, capacity int, netNsPath string) *macvtapDevicePlugin {
+func NewMacvtapDevicePlugin(name string, lowerDevice string, mode string, capacity int, netNsPath string) *macvtapDevicePlugin {
 	return &macvtapDevicePlugin{
 		Name:        name,
-		Master:      master,
+		LowerDevice: lowerDevice,
 		Mode:        mode,
 		Capacity:    capacity,
 		NetNsPath:   netNsPath,
@@ -62,47 +62,47 @@ func (mdp *macvtapDevicePlugin) generateMacvtapDevices() []*pluginapi.Device {
 }
 
 func (mdp *macvtapDevicePlugin) ListAndWatch(e *pluginapi.Empty, s pluginapi.DevicePlugin_ListAndWatchServer) error {
-	// Initialize two arrays, one for devices offered when master exists,
-	// and no devices if master does not exist.
+	// Initialize two arrays, one for devices offered when lower device exists,
+	// and no devices if lower device does not exist.
 	allocatableDevs := mdp.generateMacvtapDevices()
 	emptyDevs := make([]*pluginapi.Device, 0)
 
-	emitResponse := func(masterExists bool) {
-		if masterExists {
-			glog.V(3).Info("Master exists, sending ListAndWatch response with available devices")
+	emitResponse := func(lowerDeviceExists bool) {
+		if lowerDeviceExists {
+			glog.V(3).Info("LowerDevice exists, sending ListAndWatch response with available devices")
 			s.Send(&pluginapi.ListAndWatchResponse{Devices: allocatableDevs})
 		} else {
-			glog.V(3).Info("Master does not exist, sending ListAndWatch response with no devices")
+			glog.V(3).Info("LowerDevice does not exist, sending ListAndWatch response with no devices")
 			s.Send(&pluginapi.ListAndWatchResponse{Devices: emptyDevs})
 		}
 	}
 
-	didMasterExist := false
-	onMasterEvent := func() {
-		var doesMasterExist bool
+	didLowerDeviceExist := false
+	onLowerDeviceEvent := func() {
+		var doesLowerDeviceExist bool
 		err := ns.WithNetNSPath(mdp.NetNsPath, func(_ ns.NetNS) error {
 			var err error
-			doesMasterExist, err = util.LinkExists(mdp.Master)
+			doesLowerDeviceExist, err = util.LinkExists(mdp.LowerDevice)
 			return err
 		})
 		if err != nil {
-			glog.Warningf("Error while checking on master %s: %v", mdp.Master, err)
+			glog.Warningf("Error while checking on lower device %s: %v", mdp.LowerDevice, err)
 			return
 		}
 
-		if didMasterExist != doesMasterExist {
-			emitResponse(doesMasterExist)
-			didMasterExist = doesMasterExist
+		if didLowerDeviceExist != doesLowerDeviceExist {
+			emitResponse(doesLowerDeviceExist)
+			didLowerDeviceExist = doesLowerDeviceExist
 		}
 	}
 
-	// Listen for events of master interface. On any, check if master a
-	// interface exists. If it does, offer up to capacity macvtap devices. Do
+	// Listen for events of lower device interface. On any, check if lower
+	// device exists. If it does, offer up to capacity macvtap devices. Do
 	// not offer any otherwise.
 	util.OnLinkEvent(
-		mdp.Master,
+		mdp.LowerDevice,
 		mdp.NetNsPath,
-		onMasterEvent,
+		onLowerDeviceEvent,
 		mdp.stopWatcher,
 		func(err error) {
 			glog.Error(err)
@@ -130,7 +130,7 @@ func (mdp *macvtapDevicePlugin) Allocate(ctx context.Context, r *pluginapi.Alloc
 			var index int
 			err := ns.WithNetNSPath(mdp.NetNsPath, func(_ ns.NetNS) error {
 				var err error
-				index, err = util.RecreateMacvtap(name, mdp.Master, mdp.Mode)
+				index, err = util.RecreateMacvtap(name, mdp.LowerDevice, mdp.Mode)
 				return err
 			})
 			if err != nil {

--- a/pkg/util/netlink.go
+++ b/pkg/util/netlink.go
@@ -35,12 +35,12 @@ func ModeFromString(s string) (netlink.MacvlanMode, error) {
 	}
 }
 
-func CreateMacvtap(name string, master string, mode string) (int, error) {
+func CreateMacvtap(name string, lowerDevice string, mode string) (int, error) {
 	ifindex := 0
 
-	m, err := netlink.LinkByName(master)
+	m, err := netlink.LinkByName(lowerDevice)
 	if err != nil {
-		return ifindex, fmt.Errorf("failed to lookup master %q: %v", master, err)
+		return ifindex, fmt.Errorf("failed to lookup lowerDevice %q: %v", lowerDevice, err)
 	}
 
 	nlmode, err := ModeFromString(mode)
@@ -72,12 +72,12 @@ func CreateMacvtap(name string, master string, mode string) (int, error) {
 	return ifindex, nil
 }
 
-func RecreateMacvtap(name string, master string, mode string) (int, error) {
+func RecreateMacvtap(name string, lowerDevice string, mode string) (int, error) {
 	err := LinkDelete(name)
 	if err != nil {
 		return 0, err
 	}
-	return CreateMacvtap(name, master, mode)
+	return CreateMacvtap(name, lowerDevice, mode)
 }
 
 func LinkExists(link string) (bool, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR renames the `master` attribute of the device plugin configuration to `lowerDevice` to foster inclusive language.

**Release note**:
```release-note
Rename the DP configuration `master` attribute to `lowerDevice`, thus fostering inclusive language.
```
