### PR TITLE
DaemonSet, Add Priority class

### DIFF
--- a/manifests/macvtap.yaml
+++ b/manifests/macvtap.yaml
@@ -14,6 +14,7 @@ spec:
     spec:
       hostNetwork: true
       hostPID: true
+      priorityClassName: system-node-critical
       containers:
       - name: macvtap-cni
         command: ["/macvtap-deviceplugin", "-v", "3", "-logtostderr"]

--- a/templates/macvtap.yaml.in
+++ b/templates/macvtap.yaml.in
@@ -14,6 +14,7 @@ spec:
     spec:
       hostNetwork: true
       hostPID: true
+      priorityClassName: system-node-critical
       containers:
       - name: macvtap-cni
         command: ["/macvtap-deviceplugin", "-v", "3", "-logtostderr"]


### PR DESCRIPTION
As part of https://bugzilla.redhat.com/show_bug.cgi?id=1953482
We are adding Priority Class [1] to each network component.

The motivation is to make the control plane pods less sensitive to preemption
than user workloads.

Pods that are node specific will have the higher build-in priority,
since preempting them from a specific node, makes them unavailable
until they are rescheduled on that specific node.
Pods that are network control plane, but are not node specific 
will have `system-cluster-critical`, which would still make them more important 
than user and custom workloads, but less than `system-node-critical`.

Add `system-node-critical` to `macvtap-cni` DaemonSet.
Since `macvtap-cni` pod should run on each node,
assign `system-node-critical` pc to it.

[1] https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
None
```