### PR TITLE
install-cni, Add resources requests for initContainer

### DIFF
--- a/manifests/macvtap.yaml
+++ b/manifests/macvtap.yaml
@@ -37,6 +37,10 @@ spec:
         command: ["cp", "/macvtap-cni", "/host/opt/cni/bin/macvtap"]
         image: quay.io/kubevirt/macvtap-cni:latest
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "15Mi"
         securityContext:
           privileged: true
         volumeMounts:

--- a/templates/macvtap.yaml.in
+++ b/templates/macvtap.yaml.in
@@ -37,6 +37,10 @@ spec:
         command: ["cp", "/macvtap-cni", "/host/opt/cni/bin/macvtap"]
         image: '{{ .MacvtapImage }}'
         imagePullPolicy: '{{ .ImagePullPolicy }}'
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "15Mi"
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
Add minimum required cpu and memory resources
for the initContainer.
Based on empiric checks (set limits and see the minimum
required).

The checks were did as follows:
Set CPU and memory limits. and see which are the minimal values that allow
the initConatiner to run flawlessly.
Setting the limit for development only allows to simulate a congested cluster,
which will allow only the "requests" to be fulfilled.

See https://bugzilla.redhat.com/show_bug.cgi?id=1935218

Signed-off-by: Or Shoval <oshoval@redhat.com>

```release-note
Add minimal resource requests for macvtap initContainer
```