### PR TITLE
automation: remove SIGSTOP signal trap

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -21,7 +21,7 @@ main() {
 
     make cluster-down
     make cluster-up
-    trap teardown EXIT SIGINT SIGTERM SIGSTOP
+    trap teardown EXIT SIGINT SIGTERM
     make cluster-sync
     make test/e2e
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

Th SIGSTOP signal cannot be trapped; let's ditch it.

**What this PR does / why we need it**:
Having it there - or not - amounts to the same; let's have only meaningful instructions in the code.

```release-note
NONE
```