### PR TITLE
Typo in configuration sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ spec:
   config: '{
       "cniVersion": "0.3.1",
       "name": "dataplane",
-      "type": "macvtap-cni"
+      "type": "macvtap"
       "mtu": 1500
     }'
 ```


### PR DESCRIPTION
The actual CNI binary is 'macvtap' and not 'macvtap-cni'. Therefore, the configuration sample is not working. The description of the field `type` below is ok, but the configuration sample is missleading.

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix documentation error

**Special notes for your reviewer**:
