### PR TITLE
multus, tests: update to new network status format

### DIFF
--- a/tests/e2e/macvtap_test.go
+++ b/tests/e2e/macvtap_test.go
@@ -184,7 +184,9 @@ var _ = Describe("macvtap-cni", func() {
 
 					// macvtap iface is created as a secondary iface
 					macvtapNetwork := networks[1]
-					Expect(macvtapNetwork.Name).To(Equal(networkAttachmentDefinitionName))
+					Expect(macvtapNetwork.Name).To(BeElementOf(
+						networkAttachmentDefinitionName,
+						multiNetSpecNetworkName(namespace, networkAttachmentDefinitionName)))
 					Expect(macvtapNetwork.Interface).To(Equal("net1"))
 					Expect(macvtapNetwork.Mac).NotTo(BeEmpty())
 				})
@@ -309,4 +311,8 @@ func waitForPodReadiness(podName string, namespace string, timeout time.Duration
 		return len(containerStatuses) > 0 && readyContainers == len(containerStatuses)
 	}
 	Eventually(isPodReady, timeout, 1*time.Second).Should(BeTrue())
+}
+
+func multiNetSpecNetworkName(networkNamespace string, networkName string) string {
+	return fmt.Sprintf("%s/%s", networkNamespace, networkName)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In multus 3.8 the network status was fixed to comply with the
multi-net-spec - meaning the reported network names will always appear
in `<namespace>/<network-name>` format - [0].

As such, in order to enable CNAO to bump to this new version of multus
we need to temporarily accept both formats in this test.

[0] - https://github.com/k8snetworkplumbingwg/multus-cni/pull/515

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

**Special notes for your reviewer**:
Once CNAO is updated and delivers the new multus version, this test should again be updated,
to feature the multi-net-spec compliant version.