### PR TITLE
Release v0.6.1

### DIFF
--- a/version/description
+++ b/version/description
@@ -1,11 +1,8 @@
-v0.6.0
+v0.6.1
 
-Features:
-* build, podman: enable container runtime
-* build: bump k8s provider to 1.20
-* build: bump k8s API to 1.20
-* cni: stop setting ARP proxy
+Bugs:
+* multus, tests: update to new network status format
 
 ```
-docker pull quay.io/kubevirt/macvtap-cni:v0.6.0
+docker pull quay.io/kubevirt/macvtap-cni:v0.6.1
 ```

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.6.0"
+	Version = "0.6.1"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This new release will allow CNAO to deliver an updated version of multus-cni (v3.8).

**Special notes for your reviewer**:
The currently released version of [multus](https://github.com/k8snetworkplumbingwg/multus-cni) is v3.8.0, while the version provided by CNAO is v3.4.2.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
