### PR TITLE
Fix the NetworkAttachmentDefinition example

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,5 +170,5 @@ spec:
     command: ["/bin/sleep", "123"]
     resources:
       limits:
-        macvtap.network.kubevirt.io/dataplane: 1 
+        macvtap.network.kubevirt.io/dataplane: 1
 ```

--- a/README.md
+++ b/README.md
@@ -170,5 +170,5 @@ spec:
     command: ["/bin/sleep", "123"]
     resources:
       limits:
-        macvtap.network.kubevirt.io/dataplane: 1
+        macvtap.network.kubevirt.io/dataplane: 1 
 ```

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ spec:
   config: '{
       "cniVersion": "0.3.1",
       "name": "dataplane",
-      "type": "macvtap"
+      "type": "macvtap",
       "mtu": 1500
     }'
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix the NetworkAttachmentDefinition example, I got the error as follows by using it:

```shell
error loading k8s delegates k8s args: TryLoadPodDelegates: error in getting k8s network for pod: GetNetworkDelegates: failed getting the delegate: GetCNIConfig: err in getCNIConfigFromSpec: failed to unmarshal Spec.Config: invalid character '"' after object key:value pair
```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
