### PR TITLE
ci: use golang-1.16

### DIFF
--- a/automation/check-patch.setup.sh
+++ b/automation/check-patch.setup.sh
@@ -12,8 +12,8 @@ export PATH=${GOPATH}/bin:${GOROOT}/bin:${PATH}
 export GOBIN=${GOROOT}/bin/
 mkdir -p $GOBIN
 
-echo 'Install Go 1.13'
-export GIMME_GO_VERSION=1.13
+echo 'Install Go 1.16'
+export GIMME_GO_VERSION=1.16
 GIMME=/tmp/macvtap-cni/go/gimme
 mkdir -p $GIMME
 curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=${GIMME} bash >> ${GIMME}/gimme.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We were still running the unit / func tests using golang 1.13, which has been unsupported since 11 Aug 2020. 

The proposed version - 1.16 - is also unsupported, but we need a follow-up PR to bump both k8s to 1.23 *and* golang to 1.17.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
