### PR TITLE
config, scc: add required parameters

### DIFF
--- a/templates/scc.yaml.in
+++ b/templates/scc.yaml.in
@@ -6,6 +6,10 @@ metadata:
 allowHostNetwork: true
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostPID: false
+allowHostPorts: false
+readOnlyRootFilesystem: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
According to [openshift's API specification](https://docs.openshift.com/container-platform/4.10/rest_api/security_apis/securitycontextconstraints-security-openshift-io-v1.html) the following
attributes are required:

allowHostDirVolumePlugin
allowHostIPC
allowHostNetwork
allowHostPID
allowHostPorts
allowPrivilegedContainer
readOnlyRootFilesystem

This commits adds the required parameters to the SCCs that were missing
them.

**Special notes for your reviewer**:
This PR is required to unlock [CNAO's PR](https://github.com/kubevirt/cluster-network-addons-operator/pull/1332) .

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add the required attributes to comply with the openshift SCC API.
```
