### PR TITLE
Release v0.7.0

### DIFF
--- a/version/description
+++ b/version/description
@@ -1,8 +1,11 @@
-v0.6.1
+v0.7.0
 
+Features:
+* build: bump k8s dependencies to k8s-1.21.11
 Bugs:
-* multus, tests: update to new network status format
-
+* config, scc: add required parameters
+Docs:
+* Fix the NetworkAttachmentDefinition example
 ```
-docker pull quay.io/kubevirt/macvtap-cni:v0.6.1
+docker pull quay.io/kubevirt/macvtap-cni:v0.7.0
 ```

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.6.1"
+	Version = "0.7.0"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR release macvtap-cni 0.7.0, which features:
* build: bump k8s dependencies to k8s-1.21.11
* config, scc: add required parameters
* Fix the NetworkAttachmentDefinition example


**Special notes for your reviewer**:
Unlocks CNAO PR https://github.com/kubevirt/cluster-network-addons-operator/pull/1332

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
