### PR TITLE
config, scc: add volume parameter

### DIFF
--- a/templates/scc.yaml.in
+++ b/templates/scc.yaml.in
@@ -16,3 +16,5 @@ seLinuxContext:
   type: RunAsAny
 users:
   - system:serviceaccount:{{ .Namespace }}:macvtap-cni
+volumes:
+  - hostPath


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The volume parameter is marked as required in the CRD definition - [0] -
but is not listed as required in the official openshift API - [1].

The tracker bug requesting the API documentation to be updated can be
found in [2].

[0] - https://github.com/openshift/api/blob/a6156965faae5ce117e3cd3735981a3fc0e27e27/security/v1/0000_03_security-openshift_01_scc.crd.yaml#L73
[1] - https://docs.openshift.com/container-platform/4.10/rest_api/security_apis/securitycontextconstraints-security-openshift-io-v1.html
[2] - https://bugzilla.redhat.com/show_bug.cgi?id=2079224

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update the SCC template with a stanza to allow all volume plugins.
```
