### PR TITLE
cluster-up: Use k8s-1.23

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -14,7 +14,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.21'
+    export KUBEVIRT_PROVIDER='k8s-1.23'
 
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export KUBEVIRT_PROVIDER="${KUBEVIRT_PROVIDER:-k8s-1.21}"
+export KUBEVIRT_PROVIDER="${KUBEVIRT_PROVIDER:-k8s-1.23}"
 export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
 export KUBEVIRTCI_RUNTIME=${OCI_BIN:-docker}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Use k8s-1.23
As part of the effort to use podman in all network repositories,
align them to use the same baseline kubevirtci tag and k8s version.

Beside that soon we will deprecated k8s-1.21.
The kubevirtci that is used already have k8s-1.23 and this is the version
that is used also on the other network repos.

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
