### PR TITLE
podman: Use quay full image name

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage dockerfile building a container image with both binaries included
 
-FROM golang:1.16 as builder
+FROM quay.io/projectquay/golang:1.16 as builder
 ENV GOPATH=/go
 WORKDIR /go/src/github.com/kubevirt/macvtap-cni
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
Podman doesn't support short name for container image,
use explicit name.

Use quay image to overcome docker rate limits.

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
