### PR TITLE
Synch repo scc manifest

### DIFF
--- a/automation/check-patch.setup.sh
+++ b/automation/check-patch.setup.sh
@@ -27,3 +27,12 @@ cp -rf $(pwd)/. ${TMP_PROJECT_PATH}
 
 echo 'Exporting temporary project path'
 export TMP_PROJECT_PATH
+
+echo 'Ensuring the manifests are in sync'
+if [[ -n $(git status --porcelain 2>/dev/null) ]]; then
+    echo "ERROR: git tree state is not clean!"
+    echo "Run `make manifests` and commit those changes"
+    git status
+    git diff
+    exit 1
+fi

--- a/manifests/scc.yaml
+++ b/manifests/scc.yaml
@@ -6,9 +6,15 @@ metadata:
 allowHostNetwork: true
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostPID: false
+allowHostPorts: false
+readOnlyRootFilesystem: false
 runAsUser:
   type: RunAsAny
 seLinuxContext:
   type: RunAsAny
 users:
   - system:serviceaccount:default:macvtap-cni
+volumes:
+  - hostPath

--- a/templates/scc.yaml.in
+++ b/templates/scc.yaml.in
@@ -16,3 +16,5 @@ seLinuxContext:
   type: RunAsAny
 users:
   - system:serviceaccount:{{ .Namespace }}:macvtap-cni
+volumes:
+  - hostPath


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR synchronizes the `macvtap-cni` repo manifests with the defined templates.

It furthermore now adds a check to CI, ensuring these are kept synchronized.

**Special notes for your reviewer**:
Depends-on: #66 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Specify a valid SCC in the manifests.
```
