### PR TITLE
Fix nil pointer error for k8s 1.25

### DIFF
--- a/pkg/deviceplugin/plugin.go
+++ b/pkg/deviceplugin/plugin.go
@@ -157,7 +157,7 @@ func (mdp *macvtapDevicePlugin) PreStartContainer(context.Context, *pluginapi.Pr
 }
 
 func (mdp *macvtapDevicePlugin) GetDevicePluginOptions(context.Context, *pluginapi.Empty) (*pluginapi.DevicePluginOptions, error) {
-	return nil, nil
+	return &pluginapi.DevicePluginOptions{}, nil
 }
 
 func (mdp *macvtapDevicePlugin) GetPreferredAllocation(context.Context, *pluginapi.PreferredAllocationRequest) (*pluginapi.PreferredAllocationResponse, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**: 
Fix the nil pointer error when deploying to Kubernetes 1.25.  More context can be found [here](https://github.com/kubernetes/kubernetes/pull/109016#issuecomment-1255633896).

To reproduce the issue:

1. Use the minikube to create a cluster with k8s 1.25. `minikube start --kubernetes-version=v1.25`
2. Apply the configmap and the macvtap daemonset.
3.  Check the pod log `kubectl logs -f macvtap-cni-xxxxx`

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
5. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
