### PR TITLE
Release v0.9.0

### DIFF
--- a/version/description
+++ b/version/description
@@ -1,18 +1,10 @@
-v0.8.0
+v0.9.0
+Release a macvtap-cni whose device-plugin implementation
+works for Kubernetes-1.25.
 
-Mainly bumps golang to 1.17, and updates the Kubernetes dependencies to 1.23.
-
-Features:
-* build: update k8s dependencies to 1.23.6
-* ci: use golang-1.17
-* build: use a golang 1.17 builder img
-* build: bump to golang 1.17
-* podman: Use quay full image name
-* cluster-up: Use k8s-1.23
 Bugs:
-* ci: ensure manifests are in synch with the templates
-* deployment: synchronize the SCC manifest w/ the template
-* config, scc: add volume parameter
+* device-plugin, k8s-1.25: consume 1.19.3
+* build: address dependabots concerns in the gopkg.in/yaml.v3 module
 ```
-docker pull quay.io/kubevirt/macvtap-cni:v0.8.0
+docker pull quay.io/kubevirt/macvtap-cni:v0.9.0
 ```

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.8.0"
+	Version = "0.9.0"
 )


### PR DESCRIPTION
Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
New release, with bugfixes - most notably, one that allows for macvtap-cni to be deployed in K8s-1.25.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
