### PR TITLE
e2e tests: print network status annotation on error

### DIFF
--- a/tests/e2e/macvtap_test.go
+++ b/tests/e2e/macvtap_test.go
@@ -295,6 +295,9 @@ func buildMacvtapResourceRequest(resourceName string, quantity int) v1.ResourceL
 // Parse the json network reported by Multus in the networks-status annotations
 func parseNetwork(network string) ([]reportedNetwork, error) {
 	var reportedNetwork []reportedNetwork
+	if network == "" {
+		network = "[]"
+	}
 	err := json.Unmarshal([]byte(network), &reportedNetwork)
 	return reportedNetwork, err
 }

--- a/tests/e2e/macvtap_test.go
+++ b/tests/e2e/macvtap_test.go
@@ -179,7 +179,7 @@ var _ = Describe("macvtap-cni", func() {
 					// assert MAC address is found on the second interface
 					podNetworks := pod.Annotations[networkStatus]
 					networks, err := parseNetwork(podNetworks)
-					Expect(err).NotTo(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred(), netStatusAnnotationErrorDescription(podNetworks))
 					Expect(networks).To(HaveLen(2))
 
 					// macvtap iface is created as a secondary iface
@@ -214,6 +214,10 @@ var _ = Describe("macvtap-cni", func() {
 		})
 	})
 })
+
+func netStatusAnnotationErrorDescription(podNetworks string) string {
+	return fmt.Sprintf("should have been able to parse annotation: %s", podNetworks)
+}
 
 func deleteNetworkAttachmentDefinition(macvtapIfaceName string, namespace string) rest.Result {
 	return clientset.RESTClient().

--- a/tests/e2e/macvtap_test.go
+++ b/tests/e2e/macvtap_test.go
@@ -177,7 +177,8 @@ var _ = Describe("macvtap-cni", func() {
 					Expect(theContainer.Resources.Limits).To(Equal(buildMacvtapResourceRequest(lowerDevice, 1)))
 
 					// assert MAC address is found on the second interface
-					podNetworks := pod.Annotations[networkStatus]
+					podNetworks, wasAnnotationFound := pod.Annotations[networkStatus]
+					Expect(wasAnnotationFound).To(BeTrue())
 					networks, err := parseNetwork(podNetworks)
 					Expect(err).NotTo(HaveOccurred(), netStatusAnnotationErrorDescription(podNetworks))
 					Expect(networks).To(HaveLen(2))


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR prints the network status annotation when we fail on error
Without knowing the value of the annotation being read it is impossible to understand what is wrong in the test. 
By printing it, we have more information available when bumping dependencies on CI.

Furthermore, we make the test more resilient by defaulting to an empty slice of networks,
and also improve its readability by asserting the annotation is present on the pod.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
