### PR TITLE
Release v0.9.1

### DIFF
--- a/version/description
+++ b/version/description
@@ -1,10 +1,13 @@
-v0.9.0
-Release a macvtap-cni whose device-plugin implementation
-works for Kubernetes-1.25.
+v0.9.1
+Version v0.9.0 unfortunately broke the device-plugin registration for k8s-1.25
+instead of fixing it.
+This new version actually fixes the device-plugin registration order, and also
+fixes a nil pointer that was causing the macvtap-cni pods to crash-loop.
 
 Bugs:
-* device-plugin, k8s-1.25: consume 1.19.3
-* build: address dependabots concerns in the gopkg.in/yaml.v3 module
+* device plugin: fix registration order for k8s-1.25
+* build, vendor: bump to k8s-1.24
+* Fix nil pointer error for k8s 1.25
 ```
-docker pull quay.io/kubevirt/macvtap-cni:v0.9.0
+docker pull quay.io/kubevirt/macvtap-cni:v0.9.1
 ```

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.9.0"
+	Version = "0.9.1"
 )


### PR DESCRIPTION
Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Enables macvtap-cni on k8s-1.25

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
