### PR TITLE
e2e, multi-net: use non-deprecated network-status annot

### DIFF
--- a/tests/e2e/macvtap_test.go
+++ b/tests/e2e/macvtap_test.go
@@ -35,7 +35,7 @@ import (
 const (
 	macvtapResource = "macvtap.network.kubevirt.io"
 	networkResource = "k8s.v1.cni.cncf.io/networks"
-	networkStatus   = "k8s.v1.cni.cncf.io/networks-status"
+	networkStatus   = "k8s.v1.cni.cncf.io/network-status"
 )
 
 type reportedNetwork struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The `networks-status` annotation was deprecated, and replaced by the `network-status` annotation - [0].

[0] - https://github.com/k8snetworkplumbingwg/network-attachment-definition-client/commit/78b3280926a91976a12f710bdd045b41fcfd4073

**Special notes for your reviewer**:
This PR is required to unlock CNAO's bump to consume multus-v4, since in multus-v4, the old annotation was removed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
