### PR TITLE
Release v0.10.1

### DIFF
--- a/version/description
+++ b/version/description
@@ -1,14 +1,9 @@
-v0.10.0
-Version v0.9.0 unfortunately broke the device-plugin registration for k8s-1.25
-instead of fixing it.
-This new version actually fixes the device-plugin registration order, and also
-fixes a nil pointer that was causing the macvtap-cni pods to crash-loop. 
+v0.10.1
+Read the correct `network-status` annotation in e2e tests.
 
-Features:
-* build, vendor: bump to k8s-1.24
 Bugs:
-* device plugin: fix registration order for k8s-1.25
-* Fix nil pointer error for k8s 1.25
+* e2e, multi-net: use non-deprecated network-status annot
+
 ```
-docker pull quay.io/kubevirt/macvtap-cni:v0.10.0
+docker pull quay.io/kubevirt/macvtap-cni:v0.10.1
 ```

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.10.0"
+	Version = "0.10.1"
 )


### PR DESCRIPTION
Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Check the network-status annotation from the correct annotation key, rather than an obsolete one.

**Special notes for your reviewer**:
Multus-v4 no longer features this obsolete annotation, thus this PR unlocks the CNAO bump.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
