### PR TITLE
change interface suffix to prefix

### DIFF
--- a/pkg/deviceplugin/plugin.go
+++ b/pkg/deviceplugin/plugin.go
@@ -51,7 +51,7 @@ func (mdp *macvtapDevicePlugin) generateMacvtapDevices() []*pluginapi.Device {
 	}
 
 	for i := 0; i < capacity; i++ {
-		name := fmt.Sprint(prefix, mdp.Name, i)
+		name := fmt.Sprint(prefix, i, mdp.Name)
 		macvtapDevs = append(macvtapDevs, &pluginapi.Device{
 			ID:     name,
 			Health: pluginapi.Healthy,

--- a/pkg/deviceplugin/plugin.go
+++ b/pkg/deviceplugin/plugin.go
@@ -13,8 +13,8 @@ import (
 
 const (
 	tapPath = "/dev/tap"
-	// Interfaces will be named as <Name><suffix>[0-<Capacity>]
-	suffix = "Mvp"
+	// Interfaces will be named as <prefix>[0-<Capacity>]<Name>
+	prefix = "mvp"
 	// DefaultCapacity is the default when no capacity is provided
 	DefaultCapacity = 100
 	// DefaultMode is the default when no mode is provided
@@ -51,7 +51,7 @@ func (mdp *macvtapDevicePlugin) generateMacvtapDevices() []*pluginapi.Device {
 	}
 
 	for i := 0; i < capacity; i++ {
-		name := fmt.Sprint(mdp.Name, suffix, i)
+		name := fmt.Sprint(prefix, mdp.Name, i)
 		macvtapDevs = append(macvtapDevs, &pluginapi.Device{
 			ID:     name,
 			Health: pluginapi.Healthy,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
It switches the interface suffix to being a prefix.

This makes the interface name unique and prevents any udev or systemd rules to apply to the macvtap interface.

**Special notes for your reviewer**:
I'm not familiar with Go nor Github, this is untested !

I would be happy to test whether this fixes the problem I had, but I would need to know on how to build it and apply it to my k8s cluster.

In reference to: https://github.com/kubevirt/macvtap-cni/issues/95

The unit test probably must be updated.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Switched from interface suffix to prefix

This makes Macvtap interface names unique
```
