### PR TITLE
check hashicorp: Add hashicorp whitelist

### DIFF
--- a/.github/workflows/check_hashicorp_modules.yaml
+++ b/.github/workflows/check_hashicorp_modules.yaml
@@ -1,0 +1,10 @@
+name: Check HashiCorp Modules
+on: [push, pull_request]
+jobs:
+  check_modules:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Run script
+      run: ./hack/check_hashicorp.sh

--- a/hack/check_hashicorp.sh
+++ b/hack/check_hashicorp.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+allowed_hashicorp_modules=(
+    "github.com/hashicorp/errwrap"
+    "github.com/hashicorp/go-multierror"
+    "github.com/hashicorp/hcl"
+)
+
+error_found=false
+while read -r line; do
+    if ! [[ " ${allowed_hashicorp_modules[*]} " == *" $line "* ]]; then
+        echo "found non allowlisted hashicorp module: $line"
+        error_found=true
+    fi
+done < <(grep -i hashicorp go.mod | grep -o 'github.com/[^ ]*')
+
+if [[ $error_found == true ]]; then
+    echo "Non allowlisted hashicorp modules found, exiting with an error."
+    echo "HashiCorp adapted BSL, which we cant use on our projects."
+    echo "Please review the licensing, and either add it to the list if it isn't BSL,"
+    echo "or use a different library."
+    exit 1
+fi
+echo "All included hashicorp modules are allowlisted"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Validates that no hashicorp are used beside the whitelisted ones
(because they shifted to BSL license)

**Special notes for your reviewer**:
Atm no hashicorp is used, but lets protect in case someone will add.
Based on the whitelist that CNAO uses.

Need to enable and validate git actions runs.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
