### PR TITLE
kubevirtci: Use latest k8s 1.28

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -14,7 +14,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.24'
+    export KUBEVIRT_PROVIDER='k8s-1.28'
 
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export KUBEVIRT_PROVIDER="${KUBEVIRT_PROVIDER:-k8s-1.24}"
+export KUBEVIRT_PROVIDER="${KUBEVIRT_PROVIDER:-k8s-1.28}"
 export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
 export KUBEVIRTCI_RUNTIME=${OCI_BIN:-docker}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
k8s-1.24 is deprecated from latest kubevirtci

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
