### PR TITLE
pickup configmap change directly & add support of macvtap passthrough mode

### DIFF
--- a/cmd/deviceplugin/macvtap.go
+++ b/cmd/deviceplugin/macvtap.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"os"
 
 	"github.com/golang/glog"
 	"github.com/kubevirt/device-plugin-manager/pkg/dpm"
@@ -20,11 +19,14 @@ func main() {
 	// https://github.com/containernetworking/plugins/blob/master/pkg/ns/README.md
 	mainNsPath := util.GetMainThreadNetNsPath()
 
-	_, configDefined := os.LookupEnv(macvtap.ConfigEnvironmentVariable)
-	if !configDefined {
-		glog.Exitf("%s environment variable must be set", macvtap.ConfigEnvironmentVariable)
+	// _, configDefined := os.LookupEnv(macvtap.ConfigKey)
+	// if !configDefined {
+	// 	glog.Exitf("%s environment variable must be set", macvtap.ConfigKey)
+	// }
+	lister, err := macvtap.NewMacvtapLister(mainNsPath)
+	if err != nil {
+		glog.Fatal(err)
 	}
-
-	manager := dpm.NewManager(macvtap.NewMacvtapLister(mainNsPath))
+	manager := dpm.NewManager(lister)
 	manager.Run()
 }

--- a/manifests/macvtap.yaml
+++ b/manifests/macvtap.yaml
@@ -12,15 +12,13 @@ spec:
       labels:
         name: macvtap-cni
     spec:
+      serviceAccountName: macvtapdeviceplugin
       hostNetwork: true
       hostPID: true
       priorityClassName: system-node-critical
       containers:
       - name: macvtap-cni
         command: ["/macvtap-deviceplugin", "-v", "3", "-logtostderr"]
-        envFrom:
-          - configMapRef:
-              name: macvtap-deviceplugin-config
         image: quay.io/kubevirt/macvtap-cni:latest
         imagePullPolicy: Always
         resources:

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -1,0 +1,27 @@
+# create a service account for the CNI so that it could watch the configmap
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: macvtapdeviceplugin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: macvtap-cm-reader
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["configmaps"]
+  resourceNames: ["macvtap-deviceplugin-config"] #only allow read access to CNI's configmap
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: read-macvtap-cm
+subjects:
+- kind: ServiceAccount
+  name: macvtapdeviceplugin 
+roleRef:
+  kind: Role 
+  name: macvtap-cm-reader

--- a/pkg/deviceplugin/plugin_test.go
+++ b/pkg/deviceplugin/plugin_test.go
@@ -163,10 +163,11 @@ var _ = Describe("Macvtap", func() {
 	Describe("lister", func() {
 		var lister dpm.ListerInterface
 		var pluginListCh chan dpm.PluginNameList
-
+		var err error
 		BeforeEach(func() {
 			pluginListCh = make(chan dpm.PluginNameList)
-			lister = NewMacvtapLister(testNs.Path())
+			lister, err = NewMacvtapLister(testNs.Path())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		JustBeforeEach(func() {
@@ -187,11 +188,11 @@ var _ = Describe("Macvtap", func() {
 
 			BeforeEach(func() {
 				config = fmt.Sprintf(config, resourceName, lowerDeviceIfaceName, mode, capacity)
-				os.Setenv(ConfigEnvironmentVariable, config)
+				os.Setenv(ConfigKey, config)
 			})
 
 			AfterEach(func() {
-				os.Unsetenv(ConfigEnvironmentVariable)
+				os.Unsetenv(ConfigKey)
 			})
 
 			It("SHOULD report the appropriate list of resources", func() {
@@ -208,11 +209,11 @@ var _ = Describe("Macvtap", func() {
 
 		Context("WHEN provided an empty configuration", func() {
 			BeforeEach(func() {
-				os.Setenv(ConfigEnvironmentVariable, "[]")
+				os.Setenv(ConfigKey, "[]")
 			})
 
 			AfterEach(func() {
-				os.Unsetenv(ConfigEnvironmentVariable)
+				os.Unsetenv(ConfigKey)
 			})
 
 			It("SHOULD update the list of available resources", func() {

--- a/pkg/util/netlink.go
+++ b/pkg/util/netlink.go
@@ -23,6 +23,8 @@ func ModeFromString(s string) (netlink.MacvlanMode, error) {
 		return netlink.MACVLAN_MODE_PRIVATE, nil
 	case "vepa":
 		return netlink.MACVLAN_MODE_VEPA, nil
+	case "passthru":
+		return netlink.MACVLAN_MODE_PASSTHRU, nil
 	default:
 		return 0, fmt.Errorf("unknown macvtap mode: %q", s)
 	}
@@ -163,7 +165,6 @@ func OnSuitableMacvtapParentEvent(nsPath string, do func(), stop <-chan struct{}
 // * A first time, after first subscription
 // * Once every re-subscription
 // * On any event matching the predicate
-//
 func onLinkEvent(match func(netlink.Link) bool, nsPath string, do func(), stop <-chan struct{}, errcb func(error)) {
 	done := make(chan struct{})
 	defer close(done)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The device plugin only discover interface upon startup, currently there is no direct way to add/remove an interface to the configmap and let the device plugin pickup, the workaround  is to restart the device plugin pod whenever changing the configmap. this limitation is fine for fixed interface like a real hardware one, however macvtap also supports some dynamic created interface types like veth, which could come and go anytime. 

This PR let the device plugin uses k8s API to watch the configmap and apply changes directly, iso using configmap as env.
it also add macvtap passthrough mode support. 

**Special notes for your reviewer**:
in order to use the k8s api, a service account with the corresponding role is needed, I added rbac.yaml and updated the macvtap.yaml under the manifests folder. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable dynamic updates to the macvtap-cni configuration
```
