### PR TITLE
cluster: Pin kubevirtci tag

### DIFF
--- a/automation/check-patch.e2e-k8s.sh
+++ b/automation/check-patch.e2e-k8s.sh
@@ -14,7 +14,7 @@ teardown() {
 }
 
 main() {
-    export KUBEVIRT_PROVIDER='k8s-1.28'
+    export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.28}
 
     source automation/check-patch.setup.sh
     cd ${TMP_PROJECT_PATH}

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-export KUBEVIRT_PROVIDER="${KUBEVIRT_PROVIDER:-k8s-1.28}"
-export KUBEVIRTCI_TAG=2408151028-a0ad3359
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.28}
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2408151028-a0ad3359}
 export KUBEVIRTCI_RUNTIME=${OCI_BIN:-docker}
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'

--- a/cluster/cluster.sh
+++ b/cluster/cluster.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export KUBEVIRT_PROVIDER="${KUBEVIRT_PROVIDER:-k8s-1.28}"
-export KUBEVIRTCI_TAG=$(curl -L -Ss https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)
+export KUBEVIRTCI_TAG=2408151028-a0ad3359
 export KUBEVIRTCI_RUNTIME=${OCI_BIN:-docker}
 
 KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Pin tag until `KUBVIRT_WITH_CNAO_SKIP_CONFIG` is
introduced again (it was dropped by mistake).

Beside that:
Allow overriding kubevirtci params.
When running tests from other repos, the cluster that was created
should be the one vendored, so the scripts will match.
Otherwise it can cause errors (for example via CNAO).
Set `KUBEVIRTCI_TAG` and `KUBEVIRT_PROVIDER` only if not set yet.
It also allows overriding locally upon needs.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
