### PR TITLE
Add github actions to build and publish macvtap images.

### DIFF
--- a/.github/workflows/image-push-release.yaml
+++ b/.github/workflows/image-push-release.yaml
@@ -1,0 +1,55 @@
+name: Push container image
+on: 
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'  
+
+env:
+  REGISTRY: quay.io
+  IMAGE_NAME: kubevirt/macvtap-cni
+  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/s390x
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      # Add support for more platforms with QEMU (optional)
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker
+        if: github.repository_owner == 'kubevirt'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push latest Macvtap container image
+        if: github.repository_owner == 'kubevirt'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: ${{ env.BUILD_PLATFORMS }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest  
+          file: ./cmd/Dockerfile
+
+      - name: Build and push tagged Macvtap container image
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: ${{ env.BUILD_PLATFORMS }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{  github.ref_name }}
+          file: ./cmd/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ go_sources=$(call rwildcard,cmd/,*.go) $(call rwildcard,pkg/,*.go) $(call rwildc
 
 # Configure Go
 export GOOS=linux
-export GOARCH=amd64
+export GOARCH=$(shell uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
 export CGO_ENABLED=0
 export GO111MODULE=on
 export GOFLAGS=-mod=vendor
@@ -69,7 +69,7 @@ vet: $(go_sources) $(GO)
 	$(GO) vet ./pkg/... ./cmd/... ./tests/...
 
 docker-build:
-	$(OCI_BIN) build -t ${IMAGE_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} -f ./cmd/Dockerfile .
+	$(OCI_BIN) build --build-arg goarch=${GOARCH} -t ${IMAGE_REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} -f ./cmd/Dockerfile .
 
 docker-push:
 ifeq ($(OCI_BIN),podman)

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,12 +1,21 @@
 # Multi-stage dockerfile building a container image with both binaries included
 
-FROM quay.io/projectquay/golang:1.20 as builder
+FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:1.20 AS builder
 ENV GOPATH=/go
 WORKDIR /go/src/github.com/kubevirt/macvtap-cni
+ARG goarch=
+ARG TARGETOS
+ARG TARGETARCH
+ENV TARGETOS=${TARGETOS:-linux}
+ENV TARGETARCH=${TARGETARCH:-amd64}
+
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${goarch:-$TARGETARCH}
+
 COPY . .
 RUN GOOS=linux CGO_ENABLED=0 go build -o /macvtap-deviceplugin github.com/kubevirt/macvtap-cni/cmd/deviceplugin
 RUN GOOS=linux CGO_ENABLED=0 go build -o /macvtap-cni github.com/kubevirt/macvtap-cni/cmd/cni
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM --platform=linux/${TARGETARCH} registry.access.redhat.com/ubi8/ubi-minimal
 COPY --from=builder /macvtap-deviceplugin /macvtap-deviceplugin
 COPY --from=builder /macvtap-cni /macvtap-cni


### PR DESCRIPTION
Add support for multiarch (linux/amd64,linux/arm64,linux/s390x) image build with GitHub actions and publish resulting images to quay.io registry.

Signed-off-by: Ashok Pariya ashok.pariya@ibm.com

**What this PR does / why we need it**:
The Macvtap CNI image, available at [[quay.io/kubevirt/macvtap-cni](https://quay.io/repository/kubevirt/macvtap-cni?tab=tags&tag=latest)](https://quay.io/repository/kubevirt/macvtap-cni?tab=tags&tag=latest), currently supports only the amd64 architecture.
This PR introduces the necessary changes for multi-platform container image building and pushes for the macvtap-cni project, including updates to GitHub Actions, Makefile, and Dockerfile to support building and pushing the image for multiple architectures (amd64, arm64, s390x).

**Special notes for your reviewer**:

**Release note**:
```release-note
None
```
