### PR TITLE
Add multi-platform support for macvtap cni image builds.

### DIFF
--- a/automation/publish.sh
+++ b/automation/publish.sh
@@ -11,6 +11,7 @@
 source automation/check-patch.setup.sh
 cd ${TMP_PROJECT_PATH}
 
+export PLATFORMS=all
 IMAGE_TAG=${IMAGE_TAG:-$(git log -1 --pretty=%h)-$(date +%s)}
 make docker-build 
 make docker-tag-latest

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,12 +1,20 @@
 # Multi-stage dockerfile building a container image with both binaries included
 
-FROM quay.io/projectquay/golang:1.20 as builder
+FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:1.20 AS builder
 ENV GOPATH=/go
 WORKDIR /go/src/github.com/kubevirt/macvtap-cni
+ARG TARGETOS
+ARG TARGETARCH
+ENV TARGETOS=${TARGETOS:-linux}
+ENV TARGETARCH=${TARGETARCH:-amd64}
+
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${TARGETARCH}
+
 COPY . .
 RUN GOOS=linux CGO_ENABLED=0 go build -o /macvtap-deviceplugin github.com/kubevirt/macvtap-cni/cmd/deviceplugin
 RUN GOOS=linux CGO_ENABLED=0 go build -o /macvtap-cni github.com/kubevirt/macvtap-cni/cmd/cni
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM --platform=linux/${TARGETARCH} registry.access.redhat.com/ubi8/ubi-minimal
 COPY --from=builder /macvtap-deviceplugin /macvtap-deviceplugin
 COPY --from=builder /macvtap-cni /macvtap-cni

--- a/hack/build-macvtap-docker.sh
+++ b/hack/build-macvtap-docker.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+if [ -z "$PLATFORMS" ] || [ -z "$MACVTAP_IMAGE_TAGGED" ]; then
+    echo "Error: PLATFORMS, and MACVTAP_IMAGE_TAGGED must be set."
+    exit 1
+fi
+
+IFS=',' read -r -a PLATFORM_LIST <<< "$PLATFORMS"
+
+BUILD_ARGS="-f cmd/Dockerfile -t $MACVTAP_IMAGE_TAGGED . --push"
+
+if [ ${#PLATFORM_LIST[@]} -eq 1 ]; then
+    docker build --platform "$PLATFORMS" $BUILD_ARGS
+else
+    ./hack/init-buildx.sh "$DOCKER_BUILDER"
+    docker buildx build --platform "$PLATFORMS" $BUILD_ARGS
+    docker buildx rm "$DOCKER_BUILDER" 2>/dev/null || echo "Builder ${DOCKER_BUILDER} not found or already removed, skipping."
+fi

--- a/hack/build-macvtap-podman.sh
+++ b/hack/build-macvtap-podman.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+if [ -z "$PLATFORMS" ] || [ -z "$MACVTAP_IMAGE_TAGGED" ]; then
+    echo "Error: PLATFORMS, and MACVTAP_IMAGE_TAGGED must be set."
+    exit 1
+fi
+
+IFS=',' read -r -a PLATFORM_LIST <<< "$PLATFORMS"
+
+podman manifest rm "${MACVTAP_IMAGE_TAGGED}" 2>/dev/null || true
+podman manifest rm "${MARKER_IMAGE_GIT_TAGGED}" 2>/dev/null || true
+podman rmi "${MACVTAP_IMAGE_TAGGED}" 2>/dev/null || true
+podman rmi "${MARKER_IMAGE_GIT_TAGGED}" 2>/dev/null || true
+
+podman manifest create "${MACVTAP_IMAGE_TAGGED}"
+
+for platform in "${PLATFORM_LIST[@]}"; do
+    podman build \
+        --platform "$platform" \
+        --manifest "${MACVTAP_IMAGE_TAGGED}" \
+        -f cmd/Dockerfile .
+done

--- a/hack/init-buildx.sh
+++ b/hack/init-buildx.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+check_buildx() {
+  export DOCKER_CLI_EXPERIMENTAL=enabled
+
+  if ! docker buildx > /dev/null 2>&1; then
+     mkdir -p ~/.docker/cli-plugins
+     BUILDX_VERSION=$(curl -s https://api.github.com/repos/docker/buildx/releases/latest | jq -r .tag_name)
+     ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+     curl -L https://github.com/docker/buildx/releases/download/"${BUILDX_VERSION}"/buildx-"${BUILDX_VERSION}".linux-"${ARCH}" --output ~/.docker/cli-plugins/docker-buildx
+     chmod a+x ~/.docker/cli-plugins/docker-buildx
+  fi
+}
+
+create_or_use_buildx_builder() {
+  local builder_name=$1
+  if [ -z "$builder_name" ]; then
+    echo "Error: Builder name is required."
+    exit 1
+  fi
+
+  check_buildx
+
+  current_builder="$(docker buildx inspect "${builder_name}" 2>/dev/null)" || echo "Builder '${builder_name}' not found"
+
+  if ! grep -q "^Driver: docker$" <<<"${current_builder}" && \
+     grep -q "linux/amd64" <<<"${current_builder}" && \
+     grep -q "linux/arm64" <<<"${current_builder}" && \
+     grep -q "linux/s390x" <<<"${current_builder}"; then
+    echo "The current builder already has multi-architecture support (amd64, arm64, s390x)."
+    echo "Skipping setup as the builder is already configured correctly."
+    exit 0
+  fi
+
+  # Check if the builder already exists by parsing the output of `docker buildx ls`
+  # We check if the builder_name appears in the list of active builders
+  existing_builder=$(docker buildx ls | grep -w "$builder_name" | awk '{print $1}')
+
+  if [ -n "$existing_builder" ]; then
+    echo "Builder '$builder_name' already exists."
+    echo "Using existing builder '$builder_name'."
+    docker buildx use "$builder_name"
+  else
+    echo "Creating a new Docker Buildx builder: $builder_name"
+    docker buildx create --driver-opt network=host --use --name "$builder_name"
+    echo "The new builder '$builder_name' has been created and set as active."
+  fi
+}
+
+if [ $# -eq 1 ]; then
+  create_or_use_buildx_builder "$1"
+else
+  echo "Usage: $0 <builder_name>"
+  echo "Example: $0 mybuilder"
+  exit 1
+fi


### PR DESCRIPTION
These changes enable building and pushing macvtap container images for multiple platforms (amd64, s390x, arm64) from a single Dockerfile. Enhanced multi-platform support in the build process by adding a PLATFORMS argument in the Makefile for amd64, s390x, and arm64 architectures. Multi-platform build support is provided for both Docker and Podman container runtimes.

**What this PR does / why we need it**:
The Macvtap CNI image, available at [[quay.io/kubevirt/macvtap-cni](https://quay.io/repository/kubevirt/macvtap-cni?tab=tags&tag=latest)](https://quay.io/repository/kubevirt/macvtap-cni?tab=tags&tag=latest), currently supports only the amd64 architecture.
This PR introduces the necessary changes for multi-platform container image building and pushes for the macvtap-cni project, including updates  Makefile, and Dockerfile to support building and pushing the image for multiple architectures (amd64, arm64, s390x).

**Special notes for your reviewer**:
More details Build instruction and variable used is available at: https://gist.github.com/ashokpariya0/0424fb9022887c44b4da5b3f921f3df4


**Release note**:

```release-note
None
```
