### PR TITLE
Set container's TerminationMessagePolicy to FallbackToLogsOnError

### DIFF
--- a/manifests/macvtap.yaml
+++ b/manifests/macvtap.yaml
@@ -32,6 +32,7 @@ spec:
         volumeMounts:
           - name: deviceplugin
             mountPath: /var/lib/kubelet/device-plugins
+        terminationMessagePolicy: FallbackToLogsOnError
       initContainers:
       - name: install-cni
         command: ["cp", "/macvtap-cni", "/host/opt/cni/bin/macvtap"]

--- a/templates/macvtap.yaml.in
+++ b/templates/macvtap.yaml.in
@@ -32,6 +32,7 @@ spec:
         volumeMounts:
           - name: deviceplugin
             mountPath: /var/lib/kubelet/device-plugins
+        terminationMessagePolicy: FallbackToLogsOnError
       initContainers:
       - name: install-cni
         command: ["cp", "/macvtap-cni", "/host/opt/cni/bin/macvtap"]


### PR DESCRIPTION
**What this PR does / why we need it**:
set the TerminationMessagePolicy field to FallbackToLogsOnError [0]

[0]
https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#observability-termination-policy

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
