### PR TITLE
Fix e2e on k8s-1.34

### DIFF
--- a/tests/e2e/macvtap_test.go
+++ b/tests/e2e/macvtap_test.go
@@ -130,7 +130,7 @@ var _ = Describe("macvtap-cni", func() {
 
 				container := v1.Container{
 					Name:    containerName,
-					Image:   "alpine",
+					Image:   "docker.io/library/alpine:latest",
 					Command: []string{"/bin/sh", "-c", "sleep 999999"},
 					Resources: v1.ResourceRequirements{
 						Limits: buildMacvtapResourceRequest(lowerDevice, 1),


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Use explicit image name.
Its the same image, just with explicit name.

```
state:
  waiting:
    message: 'Back-off pulling image "alpine": ErrImagePull: short name mode is
      enforcing, but image name alpine:latest returns ambiguous list'
    reason: ImagePullBackOff
```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
