### PR TITLE
update golang deops and ubi8-minimal image

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage dockerfile building a container image with both binaries included
 
-FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:1.20 AS builder
+FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:1.24 AS builder
 ENV GOPATH=/go
 WORKDIR /go/src/github.com/kubevirt/macvtap-cni
 ARG TARGETOS
@@ -15,6 +15,6 @@ COPY . .
 RUN GOOS=linux CGO_ENABLED=0 go build -o /macvtap-deviceplugin github.com/kubevirt/macvtap-cni/cmd/deviceplugin
 RUN GOOS=linux CGO_ENABLED=0 go build -o /macvtap-cni github.com/kubevirt/macvtap-cni/cmd/cni
 
-FROM --platform=linux/${TARGETARCH} registry.access.redhat.com/ubi8/ubi-minimal
+FROM --platform=linux/${TARGETARCH} redhat/ubi8-minimal:8.10
 COPY --from=builder /macvtap-deviceplugin /macvtap-deviceplugin
 COPY --from=builder /macvtap-cni /macvtap-cni

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubevirt/macvtap-cni
 
-go 1.20
+go 1.24
 
 require (
 	github.com/aktau/github-release v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -530,6 +530,7 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
+golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Keep-current. Updates the ubi8-minimal image and the golang version to 1.24 to resolve a number of CVE's against the macvtap-cni image https://github.com/kubevirt/macvtap-cni/issues/146.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
