### PR TITLE
bump: golang 1.20 -> 1.25

### DIFF
--- a/automation/check-patch.setup.sh
+++ b/automation/check-patch.setup.sh
@@ -12,12 +12,13 @@ export PATH=${GOPATH}/bin:${GOROOT}/bin:${PATH}
 export GOBIN=${GOROOT}/bin/
 mkdir -p $GOBIN
 
-echo 'Install Go 1.25'
-export GIMME_GO_VERSION=1.25
-GIMME=/tmp/macvtap-cni/go/gimme
-mkdir -p $GIMME
-curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=${GIMME} bash >> ${GIMME}/gimme.sh
-source ${GIMME}/gimme.sh
+GO_VERSION=$(grep "^go " go.mod | awk '{print $2}')
+echo "Install Go ${GO_VERSION}"
+ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+curl -sL https://dl.google.com/go/go${GO_VERSION}.linux-${ARCH}.tar.gz | tar -xz -C /tmp/macvtap-cni/go
+export GOROOT=/tmp/macvtap-cni/go/go
+export GOBIN=${GOROOT}/bin/
+export PATH=${GOBIN}:${GOPATH}/bin:${PATH}
 
 echo 'Install operator repository under the temporary Go path'
 TMP_PROJECT_PATH=${GOPATH}/src/github.com/kubevirt/macvtap-cni

--- a/automation/check-patch.setup.sh
+++ b/automation/check-patch.setup.sh
@@ -12,8 +12,8 @@ export PATH=${GOPATH}/bin:${GOROOT}/bin:${PATH}
 export GOBIN=${GOROOT}/bin/
 mkdir -p $GOBIN
 
-echo 'Install Go 1.20'
-export GIMME_GO_VERSION=1.20
+echo 'Install Go 1.25'
+export GIMME_GO_VERSION=1.25
 GIMME=/tmp/macvtap-cni/go/gimme
 mkdir -p $GIMME
 curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=${GIMME} bash >> ${GIMME}/gimme.sh

--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage dockerfile building a container image with both binaries included
 
-FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:1.20 AS builder
+FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:1.25 AS builder
 ENV GOPATH=/go
 WORKDIR /go/src/github.com/kubevirt/macvtap-cni
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubevirt/macvtap-cni
 
-go 1.25
+go 1.25.0
 
 require (
 	github.com/aktau/github-release v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubevirt/macvtap-cni
 
-go 1.20
+go 1.25
 
 require (
 	github.com/aktau/github-release v0.8.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR bumps macvtap-cni to use/be built with / be shipped with golang 1.25 since 1.20 is out of support for quite some time. 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump golang to 1.25
```
