### PR TITLE
fix: use ls instead of test -S in DaemonSet probes

### DIFF
--- a/manifests/macvtap.yaml
+++ b/manifests/macvtap.yaml
@@ -38,7 +38,7 @@ spec:
             command:
             - sh
             - -c
-            - test -S /var/lib/kubelet/device-plugins/macvtap.network.kubevirt.io*
+            - ls /var/lib/kubelet/device-plugins/macvtap.network.kubevirt.io* >/dev/null 2>&1
           initialDelaySeconds: 5
           periodSeconds: 10
         livenessProbe:
@@ -46,7 +46,7 @@ spec:
             command:
             - sh
             - -c
-            - test -S /var/lib/kubelet/device-plugins/macvtap.network.kubevirt.io*
+            - ls /var/lib/kubelet/device-plugins/macvtap.network.kubevirt.io* >/dev/null 2>&1
           initialDelaySeconds: 15
           periodSeconds: 60
       initContainers:


### PR DESCRIPTION


<!--  Thanks for sending a pull request! -->

**What this PR does / why we need it**:
test -S only accepts a single argument. When the device plugin exposes multiple lower devices (e.g. ens3 and ens4), the glob pattern macvtap.network.kubevirt.io* expands to multiple socket files, causing test -S to fail with "too many arguments" and the pod to be restarted.

Replace with ls ... >/dev/null 2>&1, which handles multiple matches correctly.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow readiness / liveness probes to work when the device plugin exposes multiple lower devices
```
